### PR TITLE
Check host type and allow net connections

### DIFF
--- a/dev-entrypoint
+++ b/dev-entrypoint
@@ -5,12 +5,14 @@ set -e
 : ${APP_TEMP_PATH:="$APP_PATH/tmp"}
 : ${APP_SETUP_LOCK:="$APP_TEMP_PATH/setup.lock"}
 : ${APP_SETUP_WAIT:="5"}
+: ${HOST_DOMAIN:="host.docker.internal"}
 
 # 1: Define the functions lock and unlock our app containers setup
 # processes:
 function lock_setup { mkdir -p $APP_TEMP_PATH && touch $APP_SETUP_LOCK; }
 function unlock_setup { rm -rf $APP_SETUP_LOCK; }
 function wait_setup { echo "Waiting for app setup to finish..."; sleep $APP_SETUP_WAIT; }
+function check_host { ping -q -c1 $HOST_DOMAIN > /dev/null 2>&1; }
 
 # 2: 'Unlock' the setup process if the script exits prematurely:
 trap unlock_setup HUP INT QUIT KILL TERM EXIT
@@ -48,6 +50,13 @@ then
   fi
   # Start mailcatcher
   mailcatcher --http-ip 0.0.0.0
+
+  # check if the docker host is running on mac or windows
+  if ! check_host; then
+    HOST_IP=$(ip route | awk 'NR==1 {print $3}')
+    echo "$HOST_IP $HOST_DOMAIN" >> /etc/hosts
+  fi
+
   # 10: 'Unlock' the setup process:
   unlock_setup
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,11 +17,12 @@ require 'pundit/matchers'
 
 include WebMock::API
 
-# VCR.configure do |config|
-#   config.cassette_library_dir = "spec/fixtures/vcr_cassettes"
-#   config.hook_into :webmock
-#   config.configure_rspec_metadata!
-# end
+VCR.configure do |config|
+  config.allow_http_connections_when_no_cassette = true
+  config.cassette_library_dir = "spec/fixtures/vcr_cassettes"
+  config.hook_into :webmock
+  config.configure_rspec_metadata!
+end
 
 # Globally stub smartystreets
 stub_request(:any, /smartystreets.com/).to_return(


### PR DESCRIPTION
This PR addresses an issue for running system specs on Linux and allows system specs to run alongside VCR by setting `allow_http_connections_when_no_cassette = true`. This may be problematic in the future, but it allowed the specs to run both in docker and on the host.